### PR TITLE
Fix feature detection for libbfd, add related CI check after buildling bpftool

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,9 @@ jobs:
         run: |
           make -j -C src
           ./src/bpftool 2>&1 | grep -q Usage
+          ./src/bpftool -p version | \
+              tee /dev/stderr | \
+              jq --exit-status '.features | .libbfd and .libbpf_strict'
 
       - name: Build bpftool's documentation
         run: |

--- a/src/Makefile.feature
+++ b/src/Makefile.feature
@@ -28,13 +28,13 @@ define libbfd_build
 endef
 
 feature-libbfd := \
-  $(call libbfd_build,-lbfd -ldl)
+  $(findstring 1,$(call libbfd_build,-lbfd -ldl))
 ifneq ($(feature-libbfd),1)
   feature-libbfd-liberty := \
-    $(call libbfd_build,-lbfd -ldl -liberty)
+    $(findstring 1,$(call libbfd_build,-lbfd -ldl -liberty))
   ifneq ($(feature-libbfd-liberty),1)
-    feature-libbfd-liberty-z := \
-      $(call libbfd_build,-lbfd -ldl -liberty -lz)
+    $(findstring 1,feature-libbfd-liberty-z := \
+      $(call libbfd_build,-lbfd -ldl -liberty -lz))
   endif
 endif
 HAS_LIBBFD := $(findstring 1, \


### PR DESCRIPTION
Feature detection for libbfd is not passed down correctly to the main Makefile, leaving the disassembler for JIT-ed programs always compiled out. Fix `$(feature-libbfd)` and derivatives, and add a quick check with `bpftool version` to the CI workflow.