### PR TITLE
Fix features detection: clang and portability

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,12 +17,22 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install -y libbfd-dev libcap-dev libelf-dev python3-docutils
+          sudo apt-get update
+          sudo apt-get install -y \
+              clang libbfd-dev libcap-dev libelf-dev python3-docutils
 
       - name: Build bpftool
         run: |
           make -j -C src
+          ./src/bpftool 2>&1 | grep -q Usage
+          ./src/bpftool -p version | \
+              tee /dev/stderr | \
+              jq --exit-status '.features | .libbfd and .libbpf_strict'
+
+      - name: Build bpftool, with clang
+        run: |
+          make -C src clean
+          LLVM=1 make -j -C src
           ./src/bpftool 2>&1 | grep -q Usage
           ./src/bpftool -p version | \
               tee /dev/stderr | \

--- a/include/linux/compiler.h
+++ b/include/linux/compiler.h
@@ -5,7 +5,7 @@
 
 #include <linux/compiler_types.h>
 
-#ifdef __OPTIMIZE__
+#if defined(__OPTIMIZE__) && __has_attribute(__error__)
 # define __compiletime_assert(condition, msg, prefix, suffix)		\
 	do {								\
 		extern void prefix ## suffix(void) __compiletime_error(msg); \

--- a/src/Makefile.feature
+++ b/src/Makefile.feature
@@ -10,7 +10,7 @@ endif
 ### feature-clang-bpf-co-re
 
 feature-clang-bpf-co-re := \
-  $(shell echo 'struct s { int i; } __attribute__((preserve_access_index)); struct s foo;' | \
+  $(shell printf '%s\n' 'struct s { int i; } __attribute__((preserve_access_index)); struct s foo;' | \
     $(CLANG) -g -target bpf -S -o - -x c - 2>/dev/null | grep -q BTF_KIND_VAR && echo 1)
 
 ### feature-reallocarray
@@ -27,7 +27,7 @@ LIBBFD_PROBE += '	return 0;'
 LIBBFD_PROBE += '}'
 
 define libbfd_build
-  $(shell echo $(LIBBFD_PROBE) | \
+  $(shell printf '%b\n' $(LIBBFD_PROBE) | \
     $(CC) $(CFLAGS) -Wall -Werror $(LDFLAGS) -x c - $(1) -S -o - >/dev/null 2>&1 \
     && echo 1)
 endef
@@ -54,7 +54,7 @@ DISASSEMBLER_PROBE += '	return 0;'
 DISASSEMBLER_PROBE += '}'
 
 define disassembler_build
-  $(shell echo $(DISASSEMBLER_PROBE) | \
+  $(shell printf '%b\n' $(DISASSEMBLER_PROBE) | \
     $(CC) $(CFLAGS) -Wall -Werror $(LDFLAGS) -x c - -lbfd -lopcodes -S -o - >/dev/null 2>&1 \
     && echo 1)
 endef
@@ -70,7 +70,7 @@ ZLIB_PROBE += '	return 0;'
 ZLIB_PROBE += '}'
 
 define zlib_build
-  $(shell echo $(ZLIB_PROBE) | \
+  $(shell printf '%b\n' $(ZLIB_PROBE) | \
     $(CC) $(CFLAGS) -Wall -Werror $(LDFLAGS) -x c - -lz -S -o - >/dev/null 2>&1 \
     && echo 1)
 endef
@@ -86,7 +86,7 @@ LIBCAP_PROBE += '	return 0;'
 LIBCAP_PROBE += '}'
 
 define libcap_build
-  $(shell echo $(LIBCAP_PROBE) | \
+  $(shell printf '%b\n' $(LIBCAP_PROBE) | \
     $(CC) $(CFLAGS) -Wall -Werror $(LDFLAGS) -x c - -lcap -S -o - >/dev/null 2>&1 \
     && echo 1)
 endef

--- a/src/Makefile.feature
+++ b/src/Makefile.feature
@@ -2,6 +2,11 @@
 
 pound := \#
 
+CFLAGS_BACKUP := $(CFLAGS)
+ifneq ($(LLVM),)
+  CFLAGS += -Wno-unused-command-line-argument
+endif
+
 ### feature-clang-bpf-co-re
 
 feature-clang-bpf-co-re := \
@@ -103,3 +108,5 @@ $(call feature_print_status,$(HAS_LIBBFD),libbfd)
 
 $(foreach feature,$(filter-out libbfd,$(FEATURE_DISPLAY)), \
   $(call feature_print_status,$(feature-$(feature)),$(feature)))
+
+CFLAGS := $(CFLAGS_BACKUP)

--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -5,9 +5,13 @@ $(if $(shell [ -d "$(OUTPUT)" -a -x "$(OUTPUT)" ] && echo 1),, \
   $(error output directory "$(OUTPUT)" does not exist))
 endif
 
+LLVM_VERSION ?=
+CLANG        ?= clang$(LLVM_VERSION)
+LLVM_STRIP   ?= llvm-strip$(LLVM_VERSION)
+
 ifneq ($(LLVM),)
-  $(if $(findstring default,$(origin CC)),$(eval CC := clang))
-  $(if $(findstring default,$(origin LD)),$(eval LD := ld.lld))
+  $(if $(findstring default,$(origin CC)),$(eval CC := clang$(LLVM_VERSION)))
+  $(if $(findstring default,$(origin LD)),$(eval LD := ld.lld$(LLVM_VERSION)))
   HOSTCC ?= clang
   HOSTLD ?= ld.lld
 else
@@ -16,10 +20,6 @@ else
   HOSTCC ?= gcc
   HOSTLD ?= ld
 endif
-
-LLVM_VERSION ?=
-CLANG        ?= clang$(LLVM_VERSION)
-LLVM_STRIP   ?= llvm-strip$(LLVM_VERSION)
 
 EXTRA_WARNINGS := \
 	-Wbad-function-cast \


### PR DESCRIPTION
This should address the two issues raised in #3: `clang` erroring out of features detection because of warnings produced by unnecessary flags passed to the linker, and a portability issue related to the use of `echo` to print text including line breaks.

In another commit, fix the usage of `$(LLVM_VERSION)` in Makefile.include.

The last commits add a new CI build, this time relying on clang to build bpftool, and fix a header so that this build can succeed.