### PR TITLE
Fix Makefile error for feature-libbfd-liberty-z

### DIFF
--- a/src/Makefile.feature
+++ b/src/Makefile.feature
@@ -33,8 +33,8 @@ ifneq ($(feature-libbfd),1)
   feature-libbfd-liberty := \
     $(findstring 1,$(call libbfd_build,-lbfd -ldl -liberty))
   ifneq ($(feature-libbfd-liberty),1)
-    $(findstring 1,feature-libbfd-liberty-z := \
-      $(call libbfd_build,-lbfd -ldl -liberty -lz))
+    feature-libbfd-liberty-z := \
+      $(findstring 1,$(call libbfd_build,-lbfd -ldl -liberty -lz))
   endif
 endif
 HAS_LIBBFD := $(findstring 1, \


### PR DESCRIPTION
When attempting to strengthen libbfd feature detection in Makefile.feature, the fix was not applied properly to `feature-libbfd-liberty-z`, instead breaking feature detection for the case when libbfd is not installed. Let's repair it.

Closes: #23