### PR TITLE
[bpftool] remove BPF_OBJ_NAME_LEN restriction when looking up bpf

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -722,6 +722,7 @@ print_all_levels(__maybe_unused enum libbpf_print_level level,
 
 static int prog_fd_by_nametag(void *nametag, int **fds, bool tag)
 {
+	char prog_name[MAX_PROG_FULL_NAME];
 	unsigned int id = 0;
 	int fd, nb_fds = 0;
 	void *tmp;
@@ -754,10 +755,19 @@ static int prog_fd_by_nametag(void *nametag, int **fds, bool tag)
 			goto err_close_fd;
 		}
 
-		if ((tag && memcmp(nametag, info.tag, BPF_TAG_SIZE)) ||
-		    (!tag && strncmp(nametag, info.name, BPF_OBJ_NAME_LEN))) {
+		if (tag && memcmp(nametag, info.tag, BPF_TAG_SIZE)) {
 			close(fd);
 			continue;
+		}
+
+
+
+		if(!tag) {
+			get_prog_full_name(&info, fd, prog_name, sizeof(prog_name));
+			if(strcmp(nametag, prog_name)){
+				close(fd);
+				continue;
+			}
 		}
 
 		if (nb_fds > 0) {
@@ -820,10 +830,6 @@ int prog_parse_fds(int *argc, char ***argv, int **fds)
 		NEXT_ARGP();
 
 		name = **argv;
-		if (strlen(name) > BPF_OBJ_NAME_LEN - 1) {
-			p_err("can't parse name");
-			return -1;
-		}
 		NEXT_ARGP();
 
 		return prog_fd_by_nametag(name, fds, false);


### PR DESCRIPTION
program by name

bpftool was limiting the length of names to
[BPF_OBJ_NAME_LEN](https://github.com/libbpf/bpftool/blob/2d7bba1e8c17dd0422879c856cda66723b209952/src/common.c#L823-L826).

Since
https://github.com/libbpf/bpftool/commit/61833a284f48b90f6802c141c8356de64bb41e10
we can get the full program name from BTF.

This diffs remove the restriction of name length when running `bpftool
prog show name ${name}`.

Test:
Tested against some internal program names that were longer than
`BPF_OBJ_NAME_LEN`, here a redacted example of what was ran to test.

```
$ sudo bpftool prog show name some_long_program_name
Error: can't parse name
$ sudo ./bpftool prog show name some_long_program_name
123456789: tracing  name some_long_program_name  tag taghexa  gpl ....
...
...
...
```