### PR TITLE
ci: Build on several OS versions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,9 +6,17 @@ on:
     branches:
       - master
 
+env:
+  FEATURES: ".libbfd and .libbpf_strict"
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+    runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
@@ -20,6 +28,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
               clang libbfd-dev libcap-dev libelf-dev python3-docutils
+          case "${{ matrix.os }}" in
+              ubuntu-22.04)
+                  sudo apt-get install -y llvm
+                  FEATURES="${FEATURES} and .skeletons"
+                  ;;
+              esac
 
       - name: Build bpftool
         run: |
@@ -27,7 +41,7 @@ jobs:
           ./src/bpftool 2>&1 | grep -q Usage
           ./src/bpftool -p version | \
               tee /dev/stderr | \
-              jq --exit-status '.features | .libbfd and .libbpf_strict'
+              jq --exit-status ".features | ${FEATURES}"
 
       - name: Build bpftool, with clang
         run: |
@@ -36,9 +50,9 @@ jobs:
           ./src/bpftool 2>&1 | grep -q Usage
           ./src/bpftool -p version | \
               tee /dev/stderr | \
-              jq --exit-status '.features | .libbfd and .libbpf_strict'
+              jq --exit-status ".features | ${FEATURES}"
 
       - name: Build bpftool's documentation
         run: |
           make -j -C docs
-          grep -q ".TH BPFTOOL 8" ./docs/bpftool.8
+          grep -q '.TH "\?BPFTOOL"\? 8' ./docs/bpftool.8


### PR DESCRIPTION
Use a matrix in the workflow description to build bpftool on different versions of Ubuntu (this is all the Linux runner OSes supported by GitHub at this time.