### PR TITLE
mirror: Add Dockerfile: run bpftool in a container

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,36 @@
+name: docker
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - master
+
+jobs:
+  dockerimage:
+    name: Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Build bpftool container image
+        uses: docker/build-push-action@v3
+        with:
+          push: false
+          tags: bpftool:latest
+
+      - name: Test bpftool container image
+        run: |
+          docker run --rm --privileged --pid=host bpftool version
+          docker run --rm --privileged --pid=host bpftool prog
+          docker run --rm --privileged --pid=host bpftool map
+
+      - name: Lint Docker image
+        uses: luke142367/Docker-Lint-Action@5c4c86226f39785a66827bbc2e322600c9afa3a9
+        with:
+          target: Dockerfile
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# With this Dockerfile, you can create a container image:
+#     $ docker build -f Dockerfile -t bpftool .
+# And then use it:
+#     $ docker run --rm -ti --privileged --pid=host bpftool prog
+
+FROM ubuntu:22.04 as builder
+
+RUN \
+	export DEBIAN_FRONTEND=noninteractive && \
+	apt-get update && \
+	apt-get -y install --no-install-recommends \
+		build-essential \
+		libelf-dev \
+		libz-dev \
+		libcap-dev \
+		clang llvm llvm-dev lld \
+		binutils-dev \
+		pkg-config && \
+	rm -rf /var/lib/apt/lists/*
+
+COPY . /src
+RUN cd /src/src && \
+	make clean && \
+	make -j $(nproc)
+
+FROM ubuntu:22.04
+RUN \
+	export DEBIAN_FRONTEND=noninteractive && \
+	apt-get update && \
+	apt-get -y install --no-install-recommends \
+		libelf1 \
+		llvm && \
+	rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /src/src/bpftool /bin/bpftool
+
+ENTRYPOINT ["/bin/bpftool"]


### PR DESCRIPTION
I often need to use bpftool on systems where it is not installed and cannot be installed. With this Dockerfile I can build and push a container image containing bpftool:
```
     $ docker build -f Dockerfile -t bpftool .
```
And use it on systems without bpftool:
```
     $ docker run --rm -ti --privileged --pid=host bpftool prog
```

cc @mauriciovasquezbernal 
