### PR TITLE
mirror: Add .gitattributes for Makefile.* syntax highlight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+src/Makefile.* linguist-language=Makefile


### PR DESCRIPTION
Add a .gitattributes file to the repository to enjoy correct syntax highlighting for src/Makefile.include and src/Makefile.feature in GitHub's interface.