### PR TITLE
ci: Use Hadolint linter for Dockerfile, revert workflow to pull_request

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,7 +1,7 @@
 name: docker
 
 on:
-  pull_request_target: {}
+  pull_request: {}
   push:
     branches:
       - master
@@ -29,8 +29,6 @@ jobs:
           docker run --rm --privileged --pid=host bpftool map
 
       - name: Lint Docker image
-        uses: luke142367/Docker-Lint-Action@5c4c86226f39785a66827bbc2e322600c9afa3a9
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
         with:
-          target: Dockerfile
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@
 # And then use it:
 #     $ docker run --rm -ti --privileged --pid=host bpftool prog
 
+# hadolint global ignore=DL3008
+
 FROM ubuntu:22.04 as builder
 
 RUN \
@@ -19,9 +21,9 @@ RUN \
 	rm -rf /var/lib/apt/lists/*
 
 COPY . /src
-RUN cd /src/src && \
-	make clean && \
-	make -j $(nproc)
+RUN \
+	make -C /src/src clean && \
+	make -C /src/src -j "$(nproc)"
 
 FROM ubuntu:22.04
 RUN \


### PR DESCRIPTION
Workflows running on `pull_request_target` events run in the context of the base of the pull request, meaning that the Docker image is built from the base and not from the merge commit. This is not what we want. Revert to `pull_request` instead.

For the linter action that we used, this means that the workflow will fail when running from fork. There is a related issue on the Action's repository, but it seems to get very little activity. Let's switch to something that looks better maintained, and that does not have issues with running from forks.

Let's address the reports raised by the new linter, Hadolint.