### PR TITLE
ci: Add paths filter to GitHub workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,13 @@
 name: build
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '.github/workflows/build.yaml'
+      - 'docs/**'
+      - 'include/**'
+      - 'libbpf/**'
+      - 'src/**'
   push:
     branches:
       - master

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,7 +1,13 @@
 name: docker
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '.github/workflows/docker.yaml'
+      - 'Dockerfile'
+      - 'include/**'
+      - 'libbpf/**'
+      - 'src/**'
   push:
     branches:
       - master

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,7 +1,10 @@
-name: "lint"
+name: lint
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '.github/workflows/lint.yaml'
+      - 'scripts/**'
   push:
     branches:
       - master

--- a/.github/workflows/static-build.yaml
+++ b/.github/workflows/static-build.yaml
@@ -1,7 +1,12 @@
 name: static LLVM build
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '.github/workflows/static-build.yaml'
+      - 'include/**'
+      - 'libbpf/**'
+      - 'src/**'
   push:
     branches:
       - master


### PR DESCRIPTION
Only run GitHub workflow relevant to a Pull Request. For example, there is no need to rebuild bpftool on a PR that only touches the script to sync with the kernel.