### PR TITLE
ci: Add workflow to build and issue static binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,121 @@
+name: build and release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]*'
+
+env:
+  # https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.0
+  LLVM_arm64: clang+llvm-15.0.0-aarch64-linux-gnu
+  LLVM_amd64: clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4 
+
+jobs:
+  build:
+    name: Build static bpftool binary
+    runs-on: ubuntu-22.04
+    env:
+      TARGETARCH: ${{ matrix.arch }}
+      FILE_STRING_ARCH_amd64: x86-64
+      FILE_STRING_ARCH_arm64: aarch64
+    strategy:
+      matrix:
+        arch: [arm64, amd64]
+
+    steps:
+      # amd64 needs the dependencies to build bpftool
+      - name: Install dependencies (amd64)
+        if: matrix.arch == 'amd64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libelf-dev libcap-dev
+
+      - name: Download and extract compiled LLVM release
+        env:
+          LLVM: ${{ env[format('LLVM_{0}', matrix.arch)] }}
+        run: |
+          curl -L https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.0/${{ env.LLVM }}.tar.xz -O
+          tar xvf ${{ env.LLVM }}.tar.xz
+
+      - name: Checkout bpftool code
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        with:
+          submodules: recursive
+          path: 'bpftool'
+
+      - name: Build static bpftool natively for amd64
+        if: matrix.arch == 'amd64'
+        working-directory: 'bpftool'
+        env:
+          LLVM: ${{ env[format('LLVM_{0}', matrix.arch)] }}
+        run: make -j $(nproc) -C src V=1 \ 
+          EXTRA_CFLAGS=--static \
+          LLVM_CONFIG="${GITHUB_WORKSPACE}/${{ env.LLVM }}/bin/llvm-config" \
+          LLVM_STRIP="${GITHUB_WORKSPACE}/${{ env.LLVM }}/bin/llvm-strip" \
+          HOSTAR="${GITHUB_WORKSPACE}/${{ env.LLVM }}/bin/llvm-ar" &&
+          /usr/bin/strip src/bpftool
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
+        if: matrix.arch == 'arm64'
+        with:
+          platforms: arm64
+
+      # The emulated build leverages Docker and Ubuntu 22.04 container image
+      # distribution to have all the needed arm64 packages.
+      - name: Build static bpftool for arm64 with emulation
+        if: matrix.arch == 'arm64'
+        env:
+          LLVM: ${{ env[format('LLVM_{0}', matrix.arch)] }}
+        run:  |
+          docker run --platform linux/arm64 --rm -v $(pwd):/build ubuntu:22.04 \
+          bash -c "apt-get update && \
+                   apt-get install -y make pkg-config libelf-dev libcap-dev clang gcc llvm binutils && \
+                   cd build/bpftool && \
+                   LLVM_CONFIG=../../${{ env.LLVM }}/bin/llvm-config EXTRA_CFLAGS=--static make -j V=1 -C src && \
+                   strip src/bpftool"
+
+      - name: Test bpftool binary
+        working-directory: 'bpftool/src'
+        env:
+          ARCH: ${{ env[format('FILE_STRING_ARCH_{0}', matrix.arch)] }}
+        run: |
+          file ./bpftool | \
+              tee /dev/stderr | \
+              grep -q "${{ env.ARCH }}"
+          ./bpftool 2>&1 | grep -q Usage
+          ./bpftool -p version | \
+              tee /dev/stderr | \
+              jq --exit-status ".features | .llvm"
+          ldd ./bpftool 2>&1 | \
+              tee /dev/stderr | \
+              grep -q 'not a dynamic executable'
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: ${{ format('bpftool_{0}', matrix.arch) }}
+          path: bpftool/src/bpftool
+
+  draft-release:
+    name: Create a draft release
+    runs-on: ubuntu-22.04
+    needs: build
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts from build
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+
+      - name: Rename binaries and compress
+        run: |
+          tar -C bpftool_amd64 -I 'gzip -9' -cvf bpftool-${{ github.ref_name }}-amd64.tar.gz bpftool
+          tar -C bpftool_arm64 -I 'gzip -9' -cvf bpftool-${{ github.ref_name }}-arm64.tar.gz bpftool
+          mv bpftool_amd64/bpftool bpftool-amd64
+          mv bpftool_arm64/bpftool bpftool-arm64
+
+      - name: Create draft release and add artifacts
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          draft: true
+          files: bpftool*


### PR DESCRIPTION
The workflow builds natively for amd64 with LLVM library and use emulation to build for arm64 with LLVM as well. The result are two static binaries with their respective compressed archives.

You can see [how the workflow acts on my fork](https://github.com/mtardy/bpftool/actions/runs/4456237417), and [how the result release page looks](https://github.com/mtardy/bpftool/releases/tag/v6.6.8) (the release has been published here, the action just creates a draft).

Honestly, GitHub action and cross-compilation/emulation (I tried both) were a bit hard to get right with the LLVM library, it took me something like 10 hours and 70 attempts + all the tests locally on amd64 and arm64.