### PR TITLE
README: fix and improve bpftool static build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,21 +112,33 @@ $ EXTRA_CFLAGS=--static make
 Note that to use the LLVM disassembler with static builds, we need a static
 version of the LLVM library installed on the system:
 
-1.  Clone and build the LLVM libraries locally.
+1.  Download a precompiled LLVM release or build it locally.
 
-    ```console
-    $ git clone https://github.com/llvm/llvm-project.git
-    $ mkdir llvm_build
-    $ cmake -S llvm-project/llvm -B llvm_build -DCMAKE_BUILD_TYPE=Release
-    $ make -j -C llvm_build llvm-config llvm-libraries
-    ```
+    - Download the appropriate
+      [release of LLVM](https://releases.llvm.org/download.html) for your
+      platform, for example on x86_64 with LLVM 15.0.0:
 
-2.  Build bpftool with `EXTRA_CFLAGS` set to `--static`, and by passing the path to
-    the relevant `llvm-config`.
+      ```console
+      $ curl -LO https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.0/clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
+      $ tar xvf clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4.tar.xz
+      $ mv clang+llvm-15.0.0-x86_64-linux-gnu-rhel-8.4 llvm_build
+      ```
+
+    - Alternatively, clone and build the LLVM libraries locally.
+
+      ```console
+      $ git clone https://github.com/llvm/llvm-project.git
+      $ mkdir llvm_build
+      $ cmake -S llvm-project/llvm -B llvm_build -DCMAKE_BUILD_TYPE=Release
+      $ make -j -C llvm_build llvm-config llvm-libraries
+      ```
+
+2.  Build bpftool with `EXTRA_CFLAGS` set to `--static`, and by passing the
+    path to the relevant `llvm-config`.
 
     ```console
     $ cd bpftool
-    $ LLVM_CONFIG=../llvm_build/bin/llvm-config EXTRA_CFLAGS=--static make -j
+    $ LLVM_CONFIG=../../llvm_build/bin/llvm-config EXTRA_CFLAGS=--static make -j -C src
     ```
 
 ### Build bpftool's man pages


### PR DESCRIPTION
- Add the alternative to download a compiled released version of LLVM instead of building it locally.
- Add the `-C src` and fix the LLVM_CONFIG supposed relative path.