### PR TITLE
Miscellaneous clean-ups for CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: true
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -12,6 +12,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   dockerimage:
     name: Docker image

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: recursive
 
       - name: Build bpftool container image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v4.0.0
         with:
           push: false
           tags: bpftool:latest
@@ -39,6 +39,6 @@ jobs:
           docker run --rm --privileged --pid=host bpftool map
 
       - name: Lint Docker image
-        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf # v3.1.0
         with:
           dockerfile: Dockerfile

--- a/.github/workflows/lint-commits.yaml
+++ b/.github/workflows/lint-commits.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint-commits.yaml
+++ b/.github/workflows/lint-commits.yaml
@@ -3,6 +3,10 @@ name: lint-commits
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   checkCommits:
     name: check commits

--- a/.github/workflows/lint-shell.yaml
+++ b/.github/workflows/lint-shell.yaml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@94e0aab03ca135d11a35e5bfc14e6746dc56e7e9
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           scandir: './scripts'

--- a/.github/workflows/lint-shell.yaml
+++ b/.github/workflows/lint-shell.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   shellcheck:
     name: ShellCheck

--- a/.github/workflows/lint-shell.yaml
+++ b/.github/workflows/lint-shell.yaml
@@ -3,7 +3,7 @@ name: lint-shell
 on:
   pull_request:
     paths:
-      - '.github/workflows/lint.yaml'
+      - '.github/workflows/lint-shell.yaml'
       - 'scripts/**'
   push:
     branches:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
           tar -xvf "${{ env.LLVM }}.tar.xz"
 
       - name: Checkout bpftool code
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: recursive
           # Create a new directory to avoid wiping out LLVM on bpftool checkout
@@ -129,7 +129,7 @@ jobs:
           sha256sum "${archive_arm64}" > "${archive_arm64}.sha256sum"
 
       - name: Checkout bpftool and libbpf code
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: recursive
           path: 'bpftool'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.after }}
+  cancel-in-progress: true
+
 env:
   # https://github.com/llvm/llvm-project/releases/tag/llvmorg-15.0.0
   LLVM_URL_PREFIX: https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.0

--- a/.github/workflows/static-build.yaml
+++ b/.github/workflows/static-build.yaml
@@ -36,7 +36,7 @@ jobs:
           tar -xvf "${{ env.LLVM_PATH }}.tar.xz"
 
       - name: Checkout bpftool
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: recursive
           # Create a new directory to avoid wiping out LLVM on bpftool checkout

--- a/.github/workflows/static-build.yaml
+++ b/.github/workflows/static-build.yaml
@@ -17,8 +17,6 @@ concurrency:
 
 jobs:
   build:
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-22.04
     env:
       LLVM_URL_PREFIX: https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.0

--- a/.github/workflows/static-build.yaml
+++ b/.github/workflows/static-build.yaml
@@ -11,6 +11,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
- ci: Add concurrency groups to cancel outdated runs
- ci: Update GitHub Actions used in CI
- ci: Remove `strategy` for static builds workflow
- ci: Fix up trigger path for ShellCheck workflow