### PR TITLE
ci: Adjust branch names from "master" to "main"

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
       - 'src/**'
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -10,7 +10,7 @@ on:
       - 'src/**'
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/lint-shell.yaml
+++ b/.github/workflows/lint-shell.yaml
@@ -7,7 +7,7 @@ on:
       - 'scripts/**'
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}

--- a/.github/workflows/static-build.yaml
+++ b/.github/workflows/static-build.yaml
@@ -9,7 +9,7 @@ on:
       - 'src/**'
   push:
     branches:
-      - master
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}


### PR DESCRIPTION
As part of the renaming of the principal branch of the repository from `master` to `main`, update the workflow definition files to run on pushes to the `main` branch.