### PR TITLE
fix CLANG_BPF_CO_RE_PROBE_CMD

### DIFF
--- a/src/Makefile.feature
+++ b/src/Makefile.feature
@@ -27,7 +27,7 @@ endif
 ### feature-clang-bpf-co-re
 
 CLANG_BPF_CO_RE_PROBE_CMD = \
-  printf '%s\n' 'struct s { int i; } __attribute__((preserve_access_index)); struct s foo;' | \
+  printf '%s\n' 'struct s { int i; } __attribute__((preserve_access_index)); struct s foo = {};' | \
     $(CLANG) -g -target bpf -S -o - -x c - $(QUIET_STDERR) | grep -q BTF_KIND_VAR
 
 ifneq ($(findstring clang-bpf-co-re,$(FEATURE_TESTS)),)


### PR DESCRIPTION
When global variables are not initialized, the original command will get incorrect results in some versions of clang environment.

Take clang 10 as an example:
```bash
clang -v
clang version 10.0.1 (kylin 10.0.1-4.p01.ky10 119f3e344eeeca8114341787f19862d28a85f6ad)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0
Found candidate GCC installation: /usr/lib/gcc/x86_64-linux-gnu/7.3.0
Selected GCC installation: /usr/bin/../lib/gcc/x86_64-linux-gnu/7.3.0
Candidate multilib: .;@m64
Selected multilib: .;@m64
```

Not initialized (current code):
```bash
[root@localhost src]# printf '%s\n' 'struct s { int i; } __attribute__((preserve_access_index)); struct s foo;' |     clang -g -target bpf -S -o - -x c - | grep BTF_KIND_
	.long	1                       # BTF_KIND_STRUCT(id = 1)
	.long	5                       # BTF_KIND_INT(id = 2)
```

Initialized (new code):
```bash
[root@localhost src]# printf '%s\n' 'struct s { int i; } __attribute__((preserve_access_index)); struct s foo={};' |     clang -g -target bpf -S -o - -x c - | grep BTF_KIND_
	.long	1                       # BTF_KIND_STRUCT(id = 1)
	.long	5                       # BTF_KIND_INT(id = 2)
	.long	9                       # BTF_KIND_VAR(id = 3)
	.long	13                      # BTF_KIND_DATASEC(id = 4)

```

This difference will affect the checking of clang-bpf-core features.
```bash
[root@localhost src]# make
...                        libbfd: [ on  ]
...               clang-bpf-co-re: [ OFF ]
...                          llvm: [ on  ]
...                        libcap: [ on  ]
```

This part of the code looks like this in the [kernel](https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git/tree/tools/build/feature/test-clang-bpf-co-re.c):
```c
struct test {
	int a;
	int b;
} __attribute__((preserve_access_index));
volatile struct test global_value_for_test = {};
```

This problem may only occur here.