### PR TITLE
mirror: fix building documentation targets

### DIFF
--- a/src/Makefile.include
+++ b/src/Makefile.include
@@ -43,7 +43,12 @@ EXTRA_WARNINGS := \
 	-Wundef \
 	-Wwrite-strings \
 
-ifeq ($(findstring s,$(filter-out --%,$(MAKEFLAGS))),)
+define descend
+  mkdir -p $(OUTPUT)$(1) && \
+    $(MAKE) --no-print-directory -C $(1) $(2)
+endef
+
+ifeq ($(findstring s,$(firstword -$(MAKEFLAGS))),)
   ifneq ($(V),1)
 
     define def_quiet_msg


### PR DESCRIPTION
Hi,

I'm trying to start building the bpftool Fedora package from this repo and ran across a strange issue which prevents me from building the documentation.

After some investigation, I found that the issue is in the callable `descend` command in `Makefile.include` (which is specific to this repo) which is currently broken due to two reasons:
1. It is defined only for cases when the output is not suppressed by either `V=1` or `-s`.
2. The condition for checking the absence of `-s` is broken and it fails every time there is a variable definition containing the letter 's'.

The `descend` command is used in documentation targets and due to these errors, these targets fail to build in the following cases:

    $ make V=1 doc
    make: Nothing to be done for 'doc'.

    $ make prefix="/usr" doc    # <- `prefix="/usr"` contains letter 's'
    make: Nothing to be done for 'doc'.

This PR fixes the two above issues by (1) defining `descend` for all cases and (2) fixing the `-s` check by querying the first word of `MAKEFLAGS` which is the correct approach for make-4.0 and higher.