### PR TITLE
mirror: Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report an issue when building or using bpftool
+---
+
+## Reporting an issue
+
+<!--
+Issues on this repository are used for two purposes:
+
+  1. Track issues that have been reported on the BPF mailing list, and are known to the maintainers
+  2. Report and track issues that are proper to the GitHub mirror (such as mirror-specific files or changes)
+
+Please report new bpftool bugs to the BPF mailing list first. More people will see your report there.
+
+- Mailing list address: bpf@vger.kernel.org
+- Mailing list subscription: http://vger.kernel.org/vger-lists.html#bpf
+- Mailing list archives: https://lore.kernel.org/bpf/
+- BPF reporting documentation: https://docs.kernel.org/bpf/bpf_devel_QA.html#q-how-do-i-report-bugs-for-bpf-kernel-code
+-->
+
+- [ ] I considered whether to report to the BPF mailing list first
+
+## Environment
+
+- bpftool version: 
+- Linux kernel version: 
+- (optionally) clang/LLVM version: 
+- ...
+
+## Describe the bug
+
+<!--
+A clear and concise description of what the bug is.
+Please consider providing reproducing steps, or - when an eBPF program is involved - a minimal reproducing example.
+-->


### PR DESCRIPTION
Add an issue template to encourage users to report issues to the BPF mailing
list rather than to GitHub Issues. The GitHub issues should be used either to:

- Track issues reported to the mailing list and known to the maintainers
- Report and track issues related to the mirror itself (mirror-specific files
  or modifications)

Signed-off-by: Quentin Monnet <qmo@kernel.org>