### PR TITLE
mirror: Always disable unused CLI arguments warning for feature probe

### DIFF
--- a/src/Makefile.feature
+++ b/src/Makefile.feature
@@ -4,9 +4,7 @@ pound := \#
 
 CFLAGS_BACKUP := $(CFLAGS)
 CFLAGS := $(EXTRA_CFLAGS)
-ifneq ($(LLVM),)
-  CFLAGS += -Wno-unused-command-line-argument
-endif
+CFLAGS += -Wno-unused-command-line-argument
 
 ifeq ($(V),1)
   LOG=$(warning $(1))


### PR DESCRIPTION
In commit 8a2d7d510ccd ("mirror: Fix features detection for building with clang") we prevented clang to error out when encountering unused command-line arguments in the feature probes, because we do add unused arguments for some of the probes when retrieving arguments from llvm-config, and we don't want probes to fail because of that.

At the time, the issue was apparent for the LLVM-based disassembler, so we added -Wno-unused-command-line-argument when $(LLVM) was enabled, only. We missed the case when we're building bpftool with clang instead of gcc, without building the LLVM disassembler. Let's disable the warning unconditionally instead to fix this case.

Fixes: #170