### PR TITLE
Makefile: Print all detected features when building source

### DIFF
--- a/src/Makefile.feature
+++ b/src/Makefile.feature
@@ -177,7 +177,6 @@ $(call LOG,Probing: feature-llvm)
 feature-llvm := $(findstring 1, $(call llvm_build))
 endif # llvm
 
-
 ### Print detection results
 
 define print_status


### PR DESCRIPTION
Fixes #181 

This PR introduces the functionality of printing all detected features when VF=1 in the repository, similar to the kernel behavior. Currently, the V=1 flag prints detailed information about feature detection, but the output is more concise when VF=1. By adding this functionality, we enhance the debugging experience by providing clear and structured feedback on the detected features during the build process.

The output of the modified `src/Makefile.feature` to display the features is as follows:

```
shankari@shankari-IdeaPad:~/bpftool/src$ VF=1 make
...                        libbfd: [ on  ]
...                libbfd-liberty: [ OFF ]
...              libbfd-liberty-z: [ OFF ]
...               clang-bpf-co-re: [ on  ]
...                          llvm: [ on  ]
...                        libcap: [ on  ]
...        disassembler-four-args: [ on  ]
...      disassembler-init-styled: [ on  ]
...                   libelf-zstd: [ OFF ]
make: Nothing to be done for 'all'.
```