### PR TITLE
bpftool: add optional verifier log level to -d flag

### DIFF
--- a/src/gen.c
+++ b/src/gen.c
@@ -1231,8 +1231,7 @@ static int do_skeleton(int argc, char **argv)
 		get_obj_name(obj_name, file);
 	opts.object_name = obj_name;
 	if (verifier_logs)
-		/* log_level1 + log_level2 + stats, but not stable UAPI */
-		opts.kernel_log_level = 1 + 2 + 4;
+		opts.kernel_log_level = verifier_log_lvl;
 	obj = bpf_object__open_mem(obj_data, file_sz, &opts);
 	if (!obj) {
 		char err_buf[256];

--- a/src/main.h
+++ b/src/main.h
@@ -79,11 +79,13 @@ extern bool json_output;
 extern bool show_pinned;
 extern bool show_pids;
 extern bool block_mount;
-extern bool verifier_logs;
 extern bool relaxed_maps;
 extern bool use_loader;
 extern struct btf *base_btf;
 extern struct hashmap *refs_table;
+
+extern bool verifier_logs;
+extern __u32 verifier_log_lvl;
 
 void __printf(1, 2) p_err(const char *fmt, ...);
 void __printf(1, 2) p_info(const char *fmt, ...);

--- a/src/prog.c
+++ b/src/prog.c
@@ -1691,8 +1691,7 @@ offload_dev:
 	set_max_rlimit();
 
 	if (verifier_logs)
-		/* log_level1 + log_level2 + stats, but not stable UAPI */
-		open_opts.kernel_log_level = 1 + 2 + 4;
+		open_opts.kernel_log_level = verifier_log_lvl;
 
 	obj = bpf_object__open_file(file, &open_opts);
 	if (!obj) {
@@ -1885,7 +1884,7 @@ static int try_loader(struct gen_loader_opts *gen)
 	memset(ctx, 0, ctx_sz);
 	ctx->sz = ctx_sz;
 	if (verifier_logs) {
-		ctx->log_level = 1 + 2 + 4;
+		ctx->log_level = verifier_log_lvl;
 		ctx->log_size = log_buf_sz;
 		log_buf = malloc(log_buf_sz);
 		if (!log_buf)
@@ -1923,8 +1922,7 @@ static int do_loader(int argc, char **argv)
 	file = GET_ARG();
 
 	if (verifier_logs)
-		/* log_level1 + log_level2 + stats, but not stable UAPI */
-		open_opts.kernel_log_level = 1 + 2 + 4;
+		open_opts.kernel_log_level = verifier_log_lvl;
 
 	obj = bpf_object__open_file(file, &open_opts);
 	if (!obj) {

--- a/src/struct_ops.c
+++ b/src/struct_ops.c
@@ -521,8 +521,7 @@ static int do_register(int argc, char **argv)
 	}
 
 	if (verifier_logs)
-		/* log_level1 + log_level2 + stats, but not stable UAPI */
-		open_opts.kernel_log_level = 1 + 2 + 4;
+		open_opts.kernel_log_level = verifier_log_lvl;
 
 	obj = bpf_object__open_file(file, &open_opts);
 	if (!obj)


### PR DESCRIPTION
This change allows to optionally set specific verifier log level when using the -d (or --debug) flag. Behavior is not changed if no value is given.

Justification: as a bpftool user I sometimes don't want the full BPF_LOG_LEVEL2 info (it might take a while to generate it when program is e.g. 100K insns) and just want the BPF_LOG_STATS to check intruction size and verification time.
Now it's possible by supplementing 'bpftool prog load' with either '--debug=4' or '-d4'.
Also possible to fully suppress verifier output and keep just libbpf debug with '-d0'.
When no value is provided it defaults to original behaviour - max verifier verbosity.