### PR TITLE
ci: Dump deprecated Ubuntu 20.04 runner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     env:
       FEATURES: .llvm and .skeletons
@@ -31,12 +31,6 @@ jobs:
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
         with:
           submodules: true
-
-      - name: Use clang-12 and not clang-11 for older Ubuntu
-        if: matrix.os == 'ubuntu-20.04'
-        run: |
-          sudo apt-get remove -y clang-11 llvm-11
-          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 50
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Ubuntu 20.04 runners for GitHub Actions have been retired. Let's remove them from the build matrix, to avoid failures in our CI.

We want to add Ubuntu 24.04 instead, but need to finalise https://github.com/libbpf/bpftool/pull/179 for that.

Link: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/