### PR TITLE
Fix flags usage for static build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Build bpftool, with libbfd, static build
         run: |
           make -C src clean
-          EXTRA_CFLAGS=--static make -j -C src V=1
+          EXTRA_LDFLAGS=-static make -j -C src V=1
           ./src/bpftool 2>&1 | grep -q Usage
           ./src/bpftool -p version | \
               tee /dev/stderr | \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,7 +87,7 @@ jobs:
         env:
           LLVM_PATH: ${{ env[format('LLVM_{0}', matrix.arch)] }}
         run: |
-          EXTRA_CFLAGS=--static \
+          EXTRA_LDFLAGS=-static \
               LLVM_CONFIG="${GITHUB_WORKSPACE}/${{ env.LLVM_PATH }}/bin/llvm-config" \
               LLVM_STRIP="${GITHUB_WORKSPACE}/${{ env.LLVM_PATH }}/bin/llvm-strip" \
               HOSTAR="${GITHUB_WORKSPACE}/${{ env.LLVM_PATH }}/bin/llvm-ar" \
@@ -112,7 +112,7 @@ jobs:
                    apt-get install -y make pkg-config gcc \
                        libelf-dev libcap-dev libstdc++-11-dev zlib1g-dev && \
                    cd /build/bpftool && \
-                   EXTRA_CFLAGS=--static \
+                   EXTRA_LDFLAGS=-static \
                        LLVM_CONFIG='/build/${{ env.LLVM_PATH }}/bin/llvm-config' \
                        LLVM_STRIP='/build/${{ env.LLVM_PATH }}/bin/llvm-strip' \
                        CLANG='/build/${{ env.LLVM_PATH }}/bin/clang' \

--- a/.github/workflows/static-build.yaml
+++ b/.github/workflows/static-build.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Build bpftool (static build, default LLVM disassembler)
         working-directory: 'bpftool'
         run: |
-          EXTRA_CFLAGS=--static \
+          EXTRA_LDFLAGS=-static \
               LLVM_CONFIG="${GITHUB_WORKSPACE}/${LLVM_PATH}/bin/llvm-config" \
               LLVM_STRIP="${GITHUB_WORKSPACE}/${LLVM_PATH}/bin/llvm-strip" \
               make -j -C src V=1

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ example, we can create a static build with the following commands:
 
 ```console
 $ cd src
-$ EXTRA_CFLAGS=--static make
+$ EXTRA_LDFLAGS=-static make
 ```
 
 Note that to use the LLVM disassembler with static builds, we need a static
@@ -150,12 +150,12 @@ version of the LLVM library installed on the system:
       $ make -j -C llvm_build llvm-config llvm-libraries
       ```
 
-2.  Build bpftool with `EXTRA_CFLAGS` set to `--static`, and by passing the
+2.  Build bpftool with `EXTRA_LDFLAGS` set to `-static`, and by passing the
     path to the relevant `llvm-config`.
 
     ```console
     $ cd bpftool
-    $ LLVM_CONFIG=../../llvm_build/bin/llvm-config EXTRA_CFLAGS=--static make -j -C src
+    $ LLVM_CONFIG=../../llvm_build/bin/llvm-config EXTRA_LDFLAGS=-static make -j -C src
     ```
 
 ### Build bpftool's man pages


### PR DESCRIPTION
The flag we've been using and documenting for static builds does the work, but is not correct:

- It should be "-static" (compiler option, as expected by gcc for example) and not "--static" (linker option, gcc translates the former into the latter when invoking the linker).

- It should not be passed with the CFLAGS (or in our case, EXTRA_CFLAGS), but instead with the LDFLAGS (or EXTRA_LDFLAGS), because it is a flag that will be passed to the linker.

Fix it in the README.md and in CI/release workflows.