### PR TITLE
doc: clarify Linux-only build support in Dependencies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ reported on the mailing list nonetheless.
 Dependencies
 ------------
 
+> [!NOTE]
+> Building bpftool is only supported on Linux. The build process relies on
+> Linux-specific headers and tools, and is not expected to work on macOS or
+> other non-Linux systems.
+
 Required:
 
 - libelf


### PR DESCRIPTION
Add a note in the Dependencies section to clarify that building bpftool is only supported on Linux, as discussed in issue [#193](https://github.com/libbpf/bpftool/issues/193). This helps prevent confusion for users attempting to build on unsupported platforms like macOS.