### PR TITLE
ci: drop libsframe installation step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,11 +45,6 @@ jobs:
               --slave /usr/bin/llvm-strip llvm-strip /usr/bin/llvm-strip-"${CLANG_VERSION}"
           echo "CLANG_VERSION=${CLANG_VERSION}" >> "${GITHUB_ENV}"
 
-      - name: Install libsframe (Ubuntu 24.04+)
-        if: matrix.os == 'ubuntu-20.04'
-        run: |
-          sudo apt-get install -y libsframe1
-
       - name: Build bpftool (default LLVM disassembler)
         run: |
           make -j -C src V=1


### PR DESCRIPTION
The intent of the step was that libsframe1 should be installed when
running the workflow on the ubuntu-24.04 runner. However, the condition
mistakenly checks for the step being run on the ubuntu-20.04 runner,
so it's currently a no-op. The workflow passed without this step being
run. Thus, we can assume libsframe1 was installed as a transitive
dependency in the previous step and the libsframe installation step can
be removed altogether.

Fixes: 6180da5d7191 ("ci: Add Ubuntu 24.04 runner (with ugly hack for static libbfd)")