### PR TITLE
add small hint for no instruction returned

### DIFF
--- a/src/prog.c
+++ b/src/prog.c
@@ -714,7 +714,7 @@ prog_dump(struct bpf_prog_info *info, enum dump_mode mode,
 
 	if (mode == DUMP_JITED) {
 		if (info->jited_prog_len == 0 || !info->jited_prog_insns) {
-			p_info("no instructions returned");
+			p_info("no instructions returned: kernel.kptr_restrict set?");
 			return -1;
 		}
 		buf = u64_to_ptr(info->jited_prog_insns);


### PR DESCRIPTION
from issue [0], when kernel.kptr_restrict set to 2, bpftool prog dump jited returns "no instructions returned", add small hint for user to check the kernel.kptr_restrict setting and set to 1 or 0 allows bpftool prog dump jited to dump the jited instructions.

[0]: https://github.com/libbpf/bpftool/issues/184