### PR TITLE
ci: publish Docker images to GHCR on release

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,14 +11,21 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
   cancel-in-progress: true
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
-  dockerimage:
-    name: Docker image
+  test:
+    name: Test Docker image
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -29,16 +36,65 @@ jobs:
       - name: Build bpftool container image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          push: false
-          tags: bpftool:latest
+          context: .
+          load: true
+          tags: bpftool:test
 
       - name: Test bpftool container image
         run: |
-          docker run --rm --privileged --pid=host bpftool version
-          docker run --rm --privileged --pid=host bpftool prog
-          docker run --rm --privileged --pid=host bpftool map
+          docker run --rm --privileged --pid=host bpftool:test version
+          docker run --rm --privileged --pid=host bpftool:test prog
+          docker run --rm --privileged --pid=host bpftool:test map
 
       - name: Lint Docker image
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: Dockerfile
+
+  build-and-push:
+    name: Build and push Docker image
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          submodules: recursive
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=auto
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Build and push bpftool container image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Extend the existing docker workflow to push images to GitHub Container Registry (ghcr.io/libbpf/bpftool) when a new tag is pushed or when changes are merged to main.

## Behavior

| Event | Action |
|-------|--------|
| Pull Request | Build and test locally (no push) |
| Push to main branch | Build multi-arch and push with `main` tag |
| Version tag (v1.0.0) | Build and push with version tag |

## Test

- [x] Tested workflow on forked repository (github.com/gyutaeb/bpftool)
